### PR TITLE
Whittles down karma import errors to text! templates.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,6 +27,8 @@ module.exports = function(config) {
 
     // list of files to exclude
     exclude: [
+	'src/js/app.js',
+        'src/js/config.js'
     ],
 
 

--- a/src/js/config.ts
+++ b/src/js/config.ts
@@ -30,7 +30,7 @@ require.config({
 
     map: {
         "*": {
-            lodash: "bower_components/lodash/lodash.min.js"
+            underscore: 'lodash'
         }
     }
 });

--- a/src/spec/test-main.js
+++ b/src/spec/test-main.js
@@ -21,7 +21,33 @@ require.config({
         'jquery': 'bower_components/jquery/dist/jquery.min',
         'lodash': 'bower_components/lodash/lodash.min',
         'backbone': 'bower_components/backbone/backbone-min',
+        'views': 'src/js/views',
+        'models': 'src/js/models',
+        'collections': 'src/js/collections',
+        'templates': 'src/js/templates',
+        'text': 'bower_components/requirejs-text/text',
         'spec': 'spec'
+    },
+
+    shim: {
+        jquery: {
+            exports: '$'
+        },
+
+        lodash: {
+            exports: '_'
+        },
+
+        backbone: {
+            deps: ['lodash', 'jquery'],
+            exports: 'Backbone'
+        }
+    },
+
+    map: {
+        "*": {
+            underscore: 'lodash'
+        }
     },
 
     // dynamically load all test files


### PR DESCRIPTION
This PR is not finished yet but it gets us most of the way back to a functional karma setup. I'm not sure what to do for the last push to resolve the text template 404's:

```
WARN [web-server]: 404: /base/src/js/templates/app-template.html
WARN [web-server]: 404: /base/src/js/templates/nest-template.html
```

I did fix the underscore issue; turns out that the solution there was properly using `map` in the `require.config`.
